### PR TITLE
Local show thumbnail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2856,9 +2856,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001228",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+      "version": "1.0.30001235",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001235.tgz",
+      "integrity": "sha512-zWEwIVqnzPkSAXOUlQnPW2oKoYb2aLQ4Q5ejdjBcnH63rfypaW34CxaeBn1VMya2XaEU3P/R2qHpWyj+l0BT1A==",
       "dev": true
     },
     "caseless": {

--- a/scripts/episode_page.rb
+++ b/scripts/episode_page.rb
@@ -140,7 +140,11 @@ class EpisodePage
             if force or !File.exists? "#{image_full_dir}/#{image_name_jpg}" then
                 i.format = 'JPEG'
                 i.write("#{image_full_dir}/#{image_name_jpg}") { self.quality = 100; self.interlace = Magick::PlaneInterlace }
+                if extension != 'jpg'
+                    FileUtils.rm  "#{image_full_dir}/#{image_name}"
+                end
             end
+
             # for the moment, set image as full. We'll thumbnailize later on.        
             @image = "/images/#{@podcast_key}/full/#{image_name_jpg}" if File.exists? "#{image_dir}/#{image_name_jpg}"
             thumbnailize(homedir, force=false)

--- a/scripts/parse_rss_itunes.rb
+++ b/scripts/parse_rss_itunes.rb
@@ -17,6 +17,7 @@ def parse_rss_itunes(homedir, unit, force_override=false)
     cover_keep_orig = (unit[:cover_keep_orig].nil? ? false : unit[:cover_keep_orig])
     audio_download = (unit[:audio_download].nil? ? false : unit[:audio_download])
     force_override = (unit[:force_override].nil? ? force_override : unit[:force_override])
+    resources_download = (unit[:resources_download].nil? ? false : unit[:resources_download])
 
     # let's do some magic
     rss_file = URI.open(url)
@@ -98,7 +99,8 @@ def parse_rss_itunes(homedir, unit, force_override=false)
     puts "#{podcast_key} - #{episodes.size} episodes"
 
     episodes.each do |episode|
-        episode.download_image(homedir, force = force_override, cover_keep_orig)
+        episode.download_resources(homedir, force = force_override) if resources_download
+        episode.download_image(homedir, force = force_override)
         episode.download_audio(homedir, force = force_override) if audio_download
         episode.write(force = force_override)
     end

--- a/scripts/podcast_resources.rb
+++ b/scripts/podcast_resources.rb
@@ -203,21 +203,19 @@ def thumbnailize(homedir, show, force=false)
     puts "Gotta generate thumbnails for: #{new_images}"
     
     new_images.each do |image_name_jpg|
-        if (force or !File.exists? "#{image_dir}/#{image_name_jpg}")  then
-            begin
-                i = Magick::Image.read("#{image_full_dir}/#{image_name}").first
-            rescue
-                i = nil
-                next
-            end
-            i.format = 'JPEG'
-            # resize
-            image_size_side = 300
-            i.resize!(image_size_side, image_size_side)
-            # convert to progressive JPEG with quality 80
-            i.write("#{image_dir}/#{image_name_jpg}") { self.quality = 70; self.interlace = Magick::PlaneInterlace }
-            # @image = "/images/#{@podcast_key}/thumbnail/#{image_name_jpg}" if File.exists? "#{image_dir}/#{image_name_jpg}"
+        begin
+            i = Magick::Image.read("#{image_name_jpg}").first
+        rescue
+            i = nil
+            next
         end
+        i.format = 'JPEG'
+        # resize
+        image_size_side = 300
+        i.resize!(image_size_side, image_size_side)
+        # convert to progressive JPEG with quality 80
+        i.write("#{image_name_jpg.gsub("/full/", "/thumbnail/")}") { self.quality = 70; self.interlace = Magick::PlaneInterlace }
+        # @image = "/images/#{@podcast_key}/thumbnail/#{image_name_jpg}" if File.exists? "#{image_dir}/#{image_name_jpg}"
     end
 end
 


### PR DESCRIPTION
fix #3 

should enable publishers to upload only their full-size image in any format, and the ruby script should do the rest.
normally if you didn't upload an episode image you should use your podcast image instead which is covered too (no thumbnailing needed I assume the cache will be used instead.)